### PR TITLE
Implement basic timecard backend

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -6,3 +6,27 @@ datasource db {
     provider = "postgresql"
     url      = env("DATABASE_URL")
 }
+
+model User {
+    id        String     @id @default(uuid())
+    email     String     @unique
+    password  String
+    viewName  String
+    timeCards TimeCard[]
+    createdAt DateTime   @default(now())
+    updatedAt DateTime   @updatedAt
+}
+
+model TimeCard {
+    id         String   @id @default(uuid())
+    user       User     @relation(fields: [userId], references: [id])
+    userId     String
+    startTime  DateTime
+    pauseTime  DateTime?
+    resumeTime DateTime?
+    endTime    DateTime?
+    createdAt  DateTime @default(now())
+    updatedAt  DateTime @updatedAt
+
+    @@index([userId])
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,7 +1,13 @@
 import express, { Request, Response } from "express";
 import cors from "cors";
 import { createServer } from "http";
+import dotenv from "dotenv";
 import { prismaClient } from "./prisma";
+import loggingMiddleware from "./middlewares/logger.middleware";
+import authRouter from "./routers/auth.router";
+import timecardRouter from "./routers/timecard.router";
+
+dotenv.config();
 
 if (!process.env.PORT) {
     throw new Error("PORT environment variable is not set");
@@ -13,6 +19,7 @@ const app = express();
 const httpServer = createServer(app);
 
 app.use(express.json());
+app.use(loggingMiddleware());
 app.use(
     cors({
         origin: process.env.CORS_ORIGIN || "*",
@@ -23,6 +30,9 @@ app.use(
 app.get("/", (req: Request, res: Response) => {
     res.send("online");
 });
+
+app.use("/auth", authRouter);
+app.use("/timecards", timecardRouter);
 
 app.set("trust proxy", true);
 

--- a/backend/src/routers/timecard.router.ts
+++ b/backend/src/routers/timecard.router.ts
@@ -1,0 +1,15 @@
+import { Router } from "express";
+import timecardService from "../services/timecard/timecard.service";
+import { authMiddleware } from "../middlewares/auth.middleware";
+
+const router = Router();
+
+router.use(authMiddleware);
+
+router.post("/start", timecardService.start);
+router.post("/pause", timecardService.pause);
+router.post("/resume", timecardService.resume);
+router.post("/stop", timecardService.stop);
+router.get("/history", timecardService.history);
+
+export default router;

--- a/backend/src/services/auth/auth.service.ts
+++ b/backend/src/services/auth/auth.service.ts
@@ -30,16 +30,6 @@ class authService {
                 },
             });
 
-            await prismaClient.category.createMany({
-                data: [
-                    { name: "食費", type: "EXPENSE", userId: user.id },
-                    { name: "交通費", type: "EXPENSE", userId: user.id },
-                    { name: "日用品", type: "EXPENSE", userId: user.id },
-                    { name: "給料", type: "INCOME", userId: user.id },
-                    { name: "投資収入", type: "INCOME", userId: user.id },
-                    { name: "仕送り", type: "INCOME", userId: user.id },
-                ],
-            });
 
             return sendSuccessResponse(res, "CREATED", {
                 data: { id: user.id },

--- a/backend/src/services/timecard/timecard.service.ts
+++ b/backend/src/services/timecard/timecard.service.ts
@@ -1,0 +1,105 @@
+import { Request, Response } from "express";
+import { prismaClient } from "../../prisma";
+import { sendErrorResponse, sendSuccessResponse } from "../../lib/sendResponse";
+
+class timecardService {
+    public static async start(req: Request, res: Response) {
+        const userId = req.user?.userId;
+        if (!userId) return sendErrorResponse(res, "UNAUTHORIZED");
+        try {
+            const existing = await prismaClient.timeCard.findFirst({
+                where: { userId, endTime: null },
+            });
+            if (existing) {
+                return sendErrorResponse(res, "CONFLICT");
+            }
+            const card = await prismaClient.timeCard.create({
+                data: { userId, startTime: new Date() },
+            });
+            return sendSuccessResponse(res, "CREATED", { data: card });
+        } catch (error) {
+            console.error("Error starting timecard:", error);
+            return sendErrorResponse(res);
+        }
+    }
+
+    public static async pause(req: Request, res: Response) {
+        const userId = req.user?.userId;
+        if (!userId) return sendErrorResponse(res, "UNAUTHORIZED");
+        try {
+            const card = await prismaClient.timeCard.findFirst({
+                where: { userId, endTime: null, pauseTime: null },
+            });
+            if (!card) {
+                return sendErrorResponse(res, "NOT_FOUND");
+            }
+            await prismaClient.timeCard.update({
+                where: { id: card.id },
+                data: { pauseTime: new Date() },
+            });
+            return sendSuccessResponse(res);
+        } catch (error) {
+            console.error("Error pausing timecard:", error);
+            return sendErrorResponse(res);
+        }
+    }
+
+    public static async resume(req: Request, res: Response) {
+        const userId = req.user?.userId;
+        if (!userId) return sendErrorResponse(res, "UNAUTHORIZED");
+        try {
+            const card = await prismaClient.timeCard.findFirst({
+                where: { userId, endTime: null, pauseTime: { not: null }, resumeTime: null },
+            });
+            if (!card) {
+                return sendErrorResponse(res, "NOT_FOUND");
+            }
+            await prismaClient.timeCard.update({
+                where: { id: card.id },
+                data: { resumeTime: new Date() },
+            });
+            return sendSuccessResponse(res);
+        } catch (error) {
+            console.error("Error resuming timecard:", error);
+            return sendErrorResponse(res);
+        }
+    }
+
+    public static async stop(req: Request, res: Response) {
+        const userId = req.user?.userId;
+        if (!userId) return sendErrorResponse(res, "UNAUTHORIZED");
+        try {
+            const card = await prismaClient.timeCard.findFirst({
+                where: { userId, endTime: null },
+            });
+            if (!card) {
+                return sendErrorResponse(res, "NOT_FOUND");
+            }
+            await prismaClient.timeCard.update({
+                where: { id: card.id },
+                data: { endTime: new Date() },
+            });
+            return sendSuccessResponse(res);
+        } catch (error) {
+            console.error("Error stopping timecard:", error);
+            return sendErrorResponse(res);
+        }
+    }
+
+    public static async history(req: Request, res: Response) {
+        const userId = req.user?.userId;
+        if (!userId) return sendErrorResponse(res, "UNAUTHORIZED");
+        try {
+            const cards = await prismaClient.timeCard.findMany({
+                where: { userId },
+                orderBy: { startTime: "desc" },
+            });
+            return sendSuccessResponse(res, "OK", { data: cards });
+        } catch (error) {
+            console.error("Error fetching history:", error);
+            return sendErrorResponse(res);
+        }
+    }
+}
+
+export default timecardService;


### PR DESCRIPTION
## Summary
- add Prisma models for `User` and `TimeCard`
- set up Express app with logging middleware and routers
- implement auth registration without category creation
- add router/service for timecard operations
- provide endpoints to start, pause, resume, stop, and get history

## Testing
- `npx prisma generate` *(fails: npm error canceled)*

------
https://chatgpt.com/codex/tasks/task_e_6850281ed5dc833194da23628088cfad